### PR TITLE
issue-6: Add navigation tools — get_finding, get_product, list_product_types, list_tests, get_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This project provides a [Model Context Protocol (MCP)](https://github.com/modelc
 
 This MCP server exposes tools for managing key DefectDojo entities:
 
-*   **Findings:** Fetch, search, create, update status, and add notes.
-*   **Products:** List available products.
+*   **Findings:** Fetch, search, get by ID, create, update status, and add notes.
+*   **Products:** List, get by ID, and count products.
+*   **Product Types:** List product type categories.
 *   **Engagements:** List, retrieve details, create, update, and close engagements.
+*   **Tests:** List and retrieve test (scan run) details.
 
 ## Installation & Running
 
@@ -90,18 +92,21 @@ The following tools are available via the MCP interface:
 *   `get_findings`: Retrieve findings with filtering (product_name, severity, active, is_mitigated, duplicate) and pagination (limit, offset).
 *   `search_findings`: Search findings using a text query, with filtering (active, is_mitigated, duplicate) and pagination.
 *   `count_findings`: Return total number of findings matching the given filters (lightweight, no full payload).
+*   `get_finding`: Get a specific finding by its ID with full details.
 *   `update_finding_status`: Change the status of a specific finding (e.g., Active, Verified, False Positive).
 *   `add_finding_note`: Add a textual note to a finding.
 *   `create_finding`: Create a new finding associated with a test.
 *   `list_products`: List products with filtering (name, prod_type, tags, external_audience, internet_accessible) and pagination.
 *   `count_products`: Return total number of products matching the given filters (lightweight, no full payload).
+*   `get_product`: Get a specific product by its ID.
+*   `list_product_types`: List all product type categories with optional name filtering and pagination.
 *   `list_engagements`: List engagements with filtering (product_id, status, name) and pagination.
 *   `get_engagement`: Get details for a specific engagement by its ID.
 *   `create_engagement`: Create a new engagement for a product.
 *   `update_engagement`: Modify details of an existing engagement.
 *   `close_engagement`: Mark an engagement as completed.
-
-*(See the original README content below for detailed usage examples of each tool)*
+*   `list_tests`: List tests (scan runs) with filtering by engagement, test type, and tags.
+*   `get_test`: Get a specific test by its ID.
 
 ## Usage Examples
 
@@ -253,6 +258,36 @@ result = await use_mcp_tool("defectdojo", "list_products", {
 })
 ```
 
+### Get Finding
+
+```python
+# Get a specific finding by ID
+result = await use_mcp_tool("defectdojo", "get_finding", {
+    "finding_id": 702704
+})
+```
+
+### Get Product
+
+```python
+# Get a specific product by ID
+result = await use_mcp_tool("defectdojo", "get_product", {
+    "product_id": 15
+})
+```
+
+### List Product Types
+
+```python
+# List all product types
+result = await use_mcp_tool("defectdojo", "list_product_types", {})
+
+# Filter product types by name
+result = await use_mcp_tool("defectdojo", "list_product_types", {
+    "name": "Docker"
+})
+```
+
 ### Count Products
 
 ```python
@@ -316,6 +351,30 @@ result = await use_mcp_tool("defectdojo", "update_engagement", {
 ```python
 result = await use_mcp_tool("defectdojo", "close_engagement", {
     "engagement_id": 101
+})
+```
+
+### List Tests
+
+```python
+# List tests for a specific engagement
+result = await use_mcp_tool("defectdojo", "list_tests", {
+    "engagement_id": 101
+})
+
+# List tests with a specific test type
+result = await use_mcp_tool("defectdojo", "list_tests", {
+    "test_type": 156,
+    "limit": 10
+})
+```
+
+### Get Test
+
+```python
+# Get a specific test by ID
+result = await use_mcp_tool("defectdojo", "get_test", {
+    "test_id": 18550
 })
 ```
 

--- a/src/defectdojo/__init__.py
+++ b/src/defectdojo/__init__.py
@@ -2,7 +2,7 @@ import os
 from mcp.server.fastmcp import FastMCP
 
 # Import registration functions
-from defectdojo import findings_tools, products_tools, engagements_tools
+from defectdojo import findings_tools, products_tools, engagements_tools, tests_tools
 
 # Initialize FastMCP server
 mcp = FastMCP("defectdojo")
@@ -11,6 +11,7 @@ mcp = FastMCP("defectdojo")
 findings_tools.register_tools(mcp)
 products_tools.register_tools(mcp)
 engagements_tools.register_tools(mcp)
+tests_tools.register_tools(mcp)
 
 
 def main():

--- a/src/defectdojo/client.py
+++ b/src/defectdojo/client.py
@@ -4,10 +4,10 @@ from typing import Any, Dict, Optional
 
 class DefectDojoClient:
     """Client for interacting with the DefectDojo API."""
-    
+
     def __init__(self, base_url: str, api_token: str):
         """Initialize the DefectDojo API client.
-        
+
         Args:
             base_url: Base URL for the DefectDojo API
             api_token: API token for authentication
@@ -18,7 +18,7 @@ class DefectDojoClient:
             "Content-Type": "application/json"
         }
         # Consider adding timeout configuration
-        self.client = httpx.AsyncClient(headers=self.headers, timeout=30.0) 
+        self.client = httpx.AsyncClient(headers=self.headers, timeout=30.0)
 
     async def _request(self, method: str, endpoint: str, params: Optional[Dict[str, Any]] = None, json: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Helper method to make API requests."""
@@ -28,7 +28,7 @@ class DefectDojoClient:
             response.raise_for_status()
             # Handle cases where response might be empty (e.g., 204 No Content)
             if response.status_code == 204:
-                return {} 
+                return {}
             return response.json()
         except httpx.HTTPStatusError as e:
             # Log or handle specific status codes if needed
@@ -43,42 +43,62 @@ class DefectDojoClient:
     async def get_findings(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Get findings with optional filters."""
         return await self._request("GET", "/api/v2/findings/", params=filters)
-    
+
     async def search_findings(self, query: str, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Search for findings using a text query."""
         params = filters or {}
         params["search"] = query
         return await self._request("GET", "/api/v2/findings/", params=params)
-    
+
     async def update_finding(self, finding_id: int, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update a finding by ID."""
         return await self._request("PATCH", f"/api/v2/findings/{finding_id}/", json=data)
-    
+
     async def add_note_to_finding(self, finding_id: int, note: str) -> Dict[str, Any]:
         """Add a note to a finding."""
         data = {"entry": note, "finding": finding_id}
         return await self._request("POST", "/api/v2/notes/", json=data)
-    
+
     async def create_finding(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new finding."""
         return await self._request("POST", "/api/v2/findings/", json=data)
-    
+
+    async def get_finding(self, finding_id: int) -> Dict[str, Any]:
+        """Get a specific finding by ID."""
+        return await self._request("GET", f"/api/v2/findings/{finding_id}/")
+
     async def get_products(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Get products with optional filters."""
         return await self._request("GET", "/api/v2/products/", params=filters)
-            
+
+    async def get_product(self, product_id: int) -> Dict[str, Any]:
+        """Get a specific product by ID."""
+        return await self._request("GET", f"/api/v2/products/{product_id}/")
+
+    async def get_product_types(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Get product types with optional filters."""
+        return await self._request("GET", "/api/v2/product_types/", params=filters)
+
+    async def get_tests(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Get tests with optional filters."""
+        return await self._request("GET", "/api/v2/tests/", params=filters)
+
+    async def get_test(self, test_id: int) -> Dict[str, Any]:
+        """Get a specific test by ID."""
+        return await self._request("GET", f"/api/v2/tests/{test_id}/")
+
     async def get_engagements(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Get engagements with optional filters."""
         return await self._request("GET", "/api/v2/engagements/", params=filters)
-    
+
     async def get_engagement(self, engagement_id: int) -> Dict[str, Any]:
         """Get a specific engagement by ID."""
         return await self._request("GET", f"/api/v2/engagements/{engagement_id}/")
-    
+
     async def create_engagement(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new engagement."""
         return await self._request("POST", "/api/v2/engagements/", json=data)
-    
+
     async def update_engagement(self, engagement_id: int, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing engagement."""
         return await self._request("PATCH", f"/api/v2/engagements/{engagement_id}/", json=data)
@@ -87,15 +107,15 @@ class DefectDojoClient:
 
 def get_client(validate_token=True, base_url=None, token=None) -> DefectDojoClient:
     """Get a configured DefectDojo client.
-    
+
     Args:
         validate_token: Whether to validate that the token is set (default: True)
         base_url: Optional base URL override for testing
         token: Optional token override for testing
-        
+
     Returns:
         A configured DefectDojoClient instance
-        
+
     Raises:
         ValueError: If DEFECTDOJO_API_TOKEN environment variable is not set and validate_token is True
     """
@@ -106,9 +126,9 @@ def get_client(validate_token=True, base_url=None, token=None) -> DefectDojoClie
 
     if not actual_base_url:
          raise ValueError("DEFECTDOJO_API_BASE environment variable or base_url argument must be provided and cannot be empty.")
-    
+
     # Only validate token if requested (e.g., skipped for tests)
     if validate_token and not actual_token:
         raise ValueError("DEFECTDOJO_API_TOKEN environment variable or token argument must be provided")
-    
+
     return DefectDojoClient(actual_base_url, actual_token)

--- a/src/defectdojo/findings_tools.py
+++ b/src/defectdojo/findings_tools.py
@@ -357,6 +357,31 @@ async def create_finding(title: str, test_id: int, severity: str, description: s
     return {"status": "success", "data": result}
 
 
+async def get_finding(finding_id: int) -> Dict[str, Any]:
+    """Get a specific finding by its ID.
+
+    Returns the full finding object including notes, tags, endpoints,
+    and all metadata fields.
+
+    Args:
+        finding_id: The unique identifier of the finding.
+
+    Returns:
+        Dictionary with status and finding data or error.
+    """
+    client = get_client()
+    result = await client.get_finding(finding_id)
+
+    if "error" in result:
+        return {
+            "status": "error",
+            "error": result["error"],
+            "details": result.get("details", ""),
+        }
+
+    return {"status": "success", "data": result}
+
+
 # --- Registration Function ---
 
 def register_tools(mcp):
@@ -364,6 +389,7 @@ def register_tools(mcp):
     mcp.tool(name="get_findings", description="Get findings with filtering options and pagination support")(get_findings)
     mcp.tool(name="search_findings", description="Search for findings using a text query with pagination support")(search_findings)
     mcp.tool(name="count_findings", description="Return total number of findings matching the given filters (lightweight, no full payload)")(count_findings)
+    mcp.tool(name="get_finding", description="Get a specific finding by its ID with full details")(get_finding)
     mcp.tool(name="update_finding_status", description="Update the status of a finding (Active, Verified, False Positive, Mitigated, Inactive)")(update_finding_status)
     mcp.tool(name="add_finding_note", description="Add a note to a finding")(add_finding_note)
     mcp.tool(name="create_finding", description="Create a new finding")(create_finding)

--- a/src/defectdojo/tests_tools.py
+++ b/src/defectdojo/tests_tools.py
@@ -1,0 +1,91 @@
+from typing import Any, Dict, Optional
+from defectdojo.client import get_client
+
+# --- Test Tool Definitions ---
+
+
+async def list_tests(
+    engagement_id: Optional[int] = None,
+    test_type: Optional[int] = None,
+    tags: Optional[str] = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """List tests with optional filtering and pagination.
+
+    Tests represent individual scan runs or manual testing sessions within
+    an engagement. Each test contains findings produced by a specific tool.
+
+    Args:
+        engagement_id: Optional engagement ID to filter tests by.
+        test_type: Optional test type ID to filter by.
+        tags: Optional tag to filter by.
+        limit: Maximum number of tests to return per page (default: 20).
+        offset: Number of records to skip (default: 0).
+
+    Returns:
+        Dictionary with status, data/error, and pagination metadata.
+    """
+    filters: Dict[str, Any] = {"limit": limit, "o": "-id"}
+
+    if engagement_id is not None:
+        filters["engagement"] = engagement_id
+    if test_type is not None:
+        filters["test_type"] = test_type
+    if tags:
+        filters["tags"] = tags
+    if offset:
+        filters["offset"] = offset
+
+    client = get_client()
+    result = await client.get_tests(filters)
+
+    if "error" in result:
+        return {
+            "status": "error",
+            "error": result["error"],
+            "details": result.get("details", ""),
+        }
+
+    applied = {k: v for k, v in filters.items() if k not in ("limit", "offset", "o")}
+    response: Dict[str, Any] = {"status": "success", "data": result}
+    if applied:
+        response["applied_filters"] = applied
+    return response
+
+
+async def get_test(test_id: int) -> Dict[str, Any]:
+    """Get a specific test by its ID.
+
+    Args:
+        test_id: The unique identifier of the test.
+
+    Returns:
+        Dictionary with status and test data or error.
+    """
+    client = get_client()
+    result = await client.get_test(test_id)
+
+    if "error" in result:
+        return {
+            "status": "error",
+            "error": result["error"],
+            "details": result.get("details", ""),
+        }
+
+    return {"status": "success", "data": result}
+
+
+# --- Registration Function ---
+
+
+def register_tools(mcp):
+    """Register test-related tools with the MCP server instance."""
+    mcp.tool(
+        name="list_tests",
+        description="List tests (scan runs) with optional filtering by engagement, test type, and tags",
+    )(list_tests)
+    mcp.tool(
+        name="get_test",
+        description="Get a specific test by its ID",
+    )(get_test)

--- a/src/defectdojo/tools.py
+++ b/src/defectdojo/tools.py
@@ -5,11 +5,12 @@ from .findings_tools import (
     get_findings,
     search_findings,
     count_findings,
+    get_finding,
     update_finding_status,
     add_finding_note,
     create_finding,
 )
-from .products_tools import list_products, count_products
+from .products_tools import list_products, count_products, get_product, list_product_types
 from .engagements_tools import (
     list_engagements,
     get_engagement,
@@ -17,6 +18,7 @@ from .engagements_tools import (
     update_engagement,
     close_engagement,
 )
+from .tests_tools import list_tests, get_test
 
 # Placeholder for the MCP instance - will be set by the main script
 mcp = None
@@ -56,6 +58,11 @@ def register_tools(mcp_instance: FastMCP):
     )(count_findings)
 
     mcp.tool(
+        name="get_finding",
+        description="Get a specific finding by its ID with full details"
+    )(get_finding)
+
+    mcp.tool(
         name="create_finding",
         description="Create a new finding"
     )(create_finding)
@@ -70,6 +77,16 @@ def register_tools(mcp_instance: FastMCP):
         name="count_products",
         description="Return total number of products matching the given filters (lightweight, no full payload)"
     )(count_products)
+
+    mcp.tool(
+        name="get_product",
+        description="Get a specific product by its ID"
+    )(get_product)
+
+    mcp.tool(
+        name="list_product_types",
+        description="List all product types (categories) with optional filtering and pagination"
+    )(list_product_types)
 
     # Register Engagement Tools
     mcp.tool(
@@ -97,3 +114,14 @@ def register_tools(mcp_instance: FastMCP):
         name="close_engagement",
         description="Close an engagement"
     )(close_engagement)
+
+    # Register Test Tools
+    mcp.tool(
+        name="list_tests",
+        description="List tests (scan runs) with optional filtering by engagement, test type, and tags"
+    )(list_tests)
+
+    mcp.tool(
+        name="get_test",
+        description="Get a specific test by its ID"
+    )(get_test)

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -1,0 +1,275 @@
+"""Tests for newly added tools: get_finding, get_product, list_product_types, list_tests, get_test."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from defectdojo.findings_tools import get_finding
+from defectdojo.products_tools import get_product, list_product_types
+from defectdojo.tests_tools import get_test, list_tests
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FINDING_RESPONSE: Dict[str, Any] = {
+    "id": 702704,
+    "title": "Potential Secret Found in Lambda",
+    "severity": "Critical",
+    "active": True,
+    "verified": True,
+}
+
+PRODUCT_RESPONSE: Dict[str, Any] = {
+    "id": 15,
+    "name": "ciq-web",
+    "prod_type": 7,
+    "tags": ["full_sdlc"],
+}
+
+PRODUCT_TYPES_RESPONSE: Dict[str, Any] = {
+    "count": 3,
+    "next": None,
+    "previous": None,
+    "results": [
+        {"id": 1, "name": "Web Applications"},
+        {"id": 7, "name": "Docker Images"},
+        {"id": 12, "name": "Infrastructure"},
+    ],
+}
+
+TEST_RESPONSE: Dict[str, Any] = {
+    "id": 18550,
+    "title": "Prowler Scan",
+    "test_type": 156,
+    "engagement": 101,
+}
+
+TESTS_LIST_RESPONSE: Dict[str, Any] = {
+    "count": 2,
+    "next": None,
+    "previous": None,
+    "results": [
+        {"id": 18550, "title": "Prowler Scan", "test_type": 156},
+        {"id": 18551, "title": "Trivy Scan", "test_type": 120},
+    ],
+}
+
+ERROR_RESPONSE: Dict[str, Any] = {
+    "error": "HTTP error: 404",
+    "details": "Not Found",
+}
+
+
+# ---------------------------------------------------------------------------
+# get_finding
+# ---------------------------------------------------------------------------
+
+
+class TestGetFinding:
+    """Tests for the get_finding tool function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        client = AsyncMock()
+        client.get_finding.return_value = FINDING_RESPONSE
+        with patch("defectdojo.findings_tools.get_client", return_value=client):
+            result = await get_finding(finding_id=702704)
+
+        assert result["status"] == "success"
+        assert result["data"]["id"] == 702704
+        assert result["data"]["severity"] == "Critical"
+        client.get_finding.assert_awaited_once_with(702704)
+
+    @pytest.mark.asyncio
+    async def test_not_found(self):
+        client = AsyncMock()
+        client.get_finding.return_value = ERROR_RESPONSE
+        with patch("defectdojo.findings_tools.get_client", return_value=client):
+            result = await get_finding(finding_id=999999)
+
+        assert result["status"] == "error"
+        assert "404" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_product
+# ---------------------------------------------------------------------------
+
+
+class TestGetProduct:
+    """Tests for the get_product tool function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        client = AsyncMock()
+        client.get_product.return_value = PRODUCT_RESPONSE
+        with patch("defectdojo.products_tools.get_client", return_value=client):
+            result = await get_product(product_id=15)
+
+        assert result["status"] == "success"
+        assert result["data"]["name"] == "ciq-web"
+        client.get_product.assert_awaited_once_with(15)
+
+    @pytest.mark.asyncio
+    async def test_not_found(self):
+        client = AsyncMock()
+        client.get_product.return_value = ERROR_RESPONSE
+        with patch("defectdojo.products_tools.get_client", return_value=client):
+            result = await get_product(product_id=999999)
+
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# list_product_types
+# ---------------------------------------------------------------------------
+
+
+class TestListProductTypes:
+    """Tests for the list_product_types tool function."""
+
+    @pytest.mark.asyncio
+    async def test_no_filters(self):
+        client = AsyncMock()
+        client.get_product_types.return_value = PRODUCT_TYPES_RESPONSE
+        with patch("defectdojo.products_tools.get_client", return_value=client):
+            result = await list_product_types()
+
+        assert result["status"] == "success"
+        assert result["data"]["count"] == 3
+        assert len(result["data"]["results"]) == 3
+        assert "applied_filters" not in result
+
+    @pytest.mark.asyncio
+    async def test_name_filter(self):
+        filtered = {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [{"id": 7, "name": "Docker Images"}],
+        }
+        client = AsyncMock()
+        client.get_product_types.return_value = filtered
+        with patch("defectdojo.products_tools.get_client", return_value=client):
+            result = await list_product_types(name="Docker")
+
+        assert result["status"] == "success"
+        assert result["applied_filters"] == {"name": "Docker"}
+
+    @pytest.mark.asyncio
+    async def test_pagination(self):
+        client = AsyncMock()
+        client.get_product_types.return_value = PRODUCT_TYPES_RESPONSE
+        with patch("defectdojo.products_tools.get_client", return_value=client):
+            result = await list_product_types(limit=10, offset=20)
+
+        assert result["status"] == "success"
+        call_args = client.get_product_types.call_args[0][0]
+        assert call_args["limit"] == 10
+        assert call_args["offset"] == 20
+
+    @pytest.mark.asyncio
+    async def test_api_error(self):
+        client = AsyncMock()
+        client.get_product_types.return_value = ERROR_RESPONSE
+        with patch("defectdojo.products_tools.get_client", return_value=client):
+            result = await list_product_types()
+
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# list_tests
+# ---------------------------------------------------------------------------
+
+
+class TestListTests:
+    """Tests for the list_tests tool function."""
+
+    @pytest.mark.asyncio
+    async def test_no_filters(self):
+        client = AsyncMock()
+        client.get_tests.return_value = TESTS_LIST_RESPONSE
+        with patch("defectdojo.tests_tools.get_client", return_value=client):
+            result = await list_tests()
+
+        assert result["status"] == "success"
+        assert result["data"]["count"] == 2
+        assert "applied_filters" not in result
+
+    @pytest.mark.asyncio
+    async def test_engagement_filter(self):
+        client = AsyncMock()
+        client.get_tests.return_value = TESTS_LIST_RESPONSE
+        with patch("defectdojo.tests_tools.get_client", return_value=client):
+            result = await list_tests(engagement_id=101)
+
+        assert result["status"] == "success"
+        assert result["applied_filters"]["engagement"] == 101
+        call_args = client.get_tests.call_args[0][0]
+        assert call_args["engagement"] == 101
+
+    @pytest.mark.asyncio
+    async def test_test_type_filter(self):
+        client = AsyncMock()
+        client.get_tests.return_value = TESTS_LIST_RESPONSE
+        with patch("defectdojo.tests_tools.get_client", return_value=client):
+            result = await list_tests(test_type=156)
+
+        assert result["status"] == "success"
+        assert result["applied_filters"]["test_type"] == 156
+
+    @pytest.mark.asyncio
+    async def test_combined_filters(self):
+        client = AsyncMock()
+        client.get_tests.return_value = TESTS_LIST_RESPONSE
+        with patch("defectdojo.tests_tools.get_client", return_value=client):
+            result = await list_tests(engagement_id=101, test_type=156, tags="prowler")
+
+        assert result["status"] == "success"
+        applied = result["applied_filters"]
+        assert applied["engagement"] == 101
+        assert applied["test_type"] == 156
+        assert applied["tags"] == "prowler"
+
+    @pytest.mark.asyncio
+    async def test_api_error(self):
+        client = AsyncMock()
+        client.get_tests.return_value = ERROR_RESPONSE
+        with patch("defectdojo.tests_tools.get_client", return_value=client):
+            result = await list_tests()
+
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# get_test
+# ---------------------------------------------------------------------------
+
+
+class TestGetTest:
+    """Tests for the get_test tool function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        client = AsyncMock()
+        client.get_test.return_value = TEST_RESPONSE
+        with patch("defectdojo.tests_tools.get_client", return_value=client):
+            result = await get_test(test_id=18550)
+
+        assert result["status"] == "success"
+        assert result["data"]["id"] == 18550
+        client.get_test.assert_awaited_once_with(18550)
+
+    @pytest.mark.asyncio
+    async def test_not_found(self):
+        client = AsyncMock()
+        client.get_test.return_value = ERROR_RESPONSE
+        with patch("defectdojo.tests_tools.get_client", return_value=client):
+            result = await get_test(test_id=999999)
+
+        assert result["status"] == "error"


### PR DESCRIPTION
## Summary

Closes #6

Add 5 new MCP tools for complete entity navigation across the DefectDojo data model:

```
Product Type → Product → Engagement → Test → Finding
```

## New Tools

| Tool | Purpose | API Endpoint |
| --- | --- | --- |
| `get_finding` | Get a specific finding by ID with full details | `GET /api/v2/findings/{id}/` |
| `get_product` | Get a specific product by ID | `GET /api/v2/products/{id}/` |
| `list_product_types` | List product type categories with optional name filter | `GET /api/v2/product_types/` |
| `list_tests` | List tests (scan runs) filtered by engagement, type, tags | `GET /api/v2/tests/` |
| `get_test` | Get a specific test by ID | `GET /api/v2/tests/{id}/` |

## Changes

### `client.py`
- Added 5 new API methods: `get_finding`, `get_product`, `get_product_types`, `get_tests`, `get_test`

### `findings_tools.py`
- Added `get_finding(finding_id)` tool function + registration

### `products_tools.py`
- Added `get_product(product_id)` tool function
- Added `list_product_types(name, limit, offset)` tool function
- Registered both new tools

### `tests_tools.py` (new file)
- Added `list_tests(engagement_id, test_type, tags, limit, offset)` tool
- Added `get_test(test_id)` tool
- Registration function for both tools

### `tools.py` + `__init__.py`
- Imported and registered all new tools from all modules including `tests_tools`

### `test_new_tools.py` (new file)
- 15 unit tests covering all 5 new tools (success + error cases)

### `README.md`
- Updated features list
- Added tool descriptions to Available Tools section
- Added usage examples for all new tools

## Testing

```
80 passed in 0.39s (was 65 before this PR)
```

All existing tests pass. 15 new tests added covering:
- Successful responses for each tool
- Error handling (404, API errors)
- Filter application and pagination for list tools
- Combined filter scenarios