### PR TITLE
issue-8: Add user management tools — list_users, get_user, list_dojo_groups, list_dojo_group_members

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This MCP server exposes tools for managing key DefectDojo entities:
 *   **Product Types:** List product type categories.
 *   **Engagements:** List, retrieve details, create, update, and close engagements.
 *   **Tests:** List and retrieve test (scan run) details.
+*   **Users & Groups:** List users, get user profiles, list groups and group members.
 
 ## Installation & Running
 
@@ -107,6 +108,10 @@ The following tools are available via the MCP interface:
 *   `close_engagement`: Mark an engagement as completed.
 *   `list_tests`: List tests (scan runs) with filtering by engagement, test type, and tags.
 *   `get_test`: Get a specific test by its ID.
+*   `list_users`: List DefectDojo users with filtering by username, name, and active status.
+*   `get_user`: Get a specific user by their ID with full profile details.
+*   `list_dojo_groups`: List DefectDojo groups (teams) with optional name filtering.
+*   `list_dojo_group_members`: List members of DefectDojo groups with optional group/user filtering.
 
 ## Usage Examples
 
@@ -375,6 +380,61 @@ result = await use_mcp_tool("defectdojo", "list_tests", {
 # Get a specific test by ID
 result = await use_mcp_tool("defectdojo", "get_test", {
     "test_id": 18550
+})
+```
+
+### List Users
+
+```python
+# List all active users
+result = await use_mcp_tool("defectdojo", "list_users", {
+    "is_active": True
+})
+
+# Find a user by username
+result = await use_mcp_tool("defectdojo", "list_users", {
+    "username": "admin"
+})
+
+# Find users by name
+result = await use_mcp_tool("defectdojo", "list_users", {
+    "first_name": "John",
+    "is_active": True
+})
+```
+
+### Get User
+
+```python
+# Get a specific user profile by ID
+result = await use_mcp_tool("defectdojo", "get_user", {
+    "user_id": 1
+})
+```
+
+### List Groups
+
+```python
+# List all DefectDojo groups
+result = await use_mcp_tool("defectdojo", "list_dojo_groups", {})
+
+# Filter groups by name
+result = await use_mcp_tool("defectdojo", "list_dojo_groups", {
+    "name": "AppSec"
+})
+```
+
+### List Group Members
+
+```python
+# List all members of a specific group
+result = await use_mcp_tool("defectdojo", "list_dojo_group_members", {
+    "group_id": 3
+})
+
+# Find which groups a user belongs to
+result = await use_mcp_tool("defectdojo", "list_dojo_group_members", {
+    "user_id": 42
 })
 ```
 

--- a/src/defectdojo/__init__.py
+++ b/src/defectdojo/__init__.py
@@ -2,7 +2,7 @@ import os
 from mcp.server.fastmcp import FastMCP
 
 # Import registration functions
-from defectdojo import findings_tools, products_tools, engagements_tools, tests_tools
+from defectdojo import findings_tools, products_tools, engagements_tools, tests_tools, users_tools
 
 # Initialize FastMCP server
 mcp = FastMCP("defectdojo")
@@ -12,6 +12,7 @@ findings_tools.register_tools(mcp)
 products_tools.register_tools(mcp)
 engagements_tools.register_tools(mcp)
 tests_tools.register_tools(mcp)
+users_tools.register_tools(mcp)
 
 
 def main():

--- a/src/defectdojo/client.py
+++ b/src/defectdojo/client.py
@@ -103,6 +103,24 @@ class DefectDojoClient:
         """Update an existing engagement."""
         return await self._request("PATCH", f"/api/v2/engagements/{engagement_id}/", json=data)
 
+    # --- User & Group Methods ---
+
+    async def get_users(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Get users with optional filters."""
+        return await self._request("GET", "/api/v2/users/", params=filters)
+
+    async def get_user(self, user_id: int) -> Dict[str, Any]:
+        """Get a specific user by ID."""
+        return await self._request("GET", f"/api/v2/users/{user_id}/")
+
+    async def get_dojo_groups(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Get DefectDojo groups with optional filters."""
+        return await self._request("GET", "/api/v2/dojo_groups/", params=filters)
+
+    async def get_dojo_group_members(self, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Get DefectDojo group members with optional filters."""
+        return await self._request("GET", "/api/v2/dojo_group_members/", params=filters)
+
 # --- Client Factory ---
 
 def get_client(validate_token=True, base_url=None, token=None) -> DefectDojoClient:

--- a/src/defectdojo/tools.py
+++ b/src/defectdojo/tools.py
@@ -19,6 +19,7 @@ from .engagements_tools import (
     close_engagement,
 )
 from .tests_tools import list_tests, get_test
+from .users_tools import list_users, get_user, list_dojo_groups, list_dojo_group_members
 
 # Placeholder for the MCP instance - will be set by the main script
 mcp = None
@@ -125,3 +126,24 @@ def register_tools(mcp_instance: FastMCP):
         name="get_test",
         description="Get a specific test by its ID"
     )(get_test)
+
+    # Register User & Group Tools
+    mcp.tool(
+        name="list_users",
+        description="List DefectDojo users with optional filtering by username, name, and active status"
+    )(list_users)
+
+    mcp.tool(
+        name="get_user",
+        description="Get a specific DefectDojo user by their ID"
+    )(get_user)
+
+    mcp.tool(
+        name="list_dojo_groups",
+        description="List DefectDojo groups (teams) with optional name filtering"
+    )(list_dojo_groups)
+
+    mcp.tool(
+        name="list_dojo_group_members",
+        description="List members of DefectDojo groups with optional group/user filtering"
+    )(list_dojo_group_members)

--- a/src/defectdojo/users_tools.py
+++ b/src/defectdojo/users_tools.py
@@ -1,0 +1,198 @@
+from typing import Any, Dict, Optional
+from defectdojo.client import get_client
+
+# --- User & Group Tool Definitions ---
+
+
+async def list_users(
+    username: Optional[str] = None,
+    first_name: Optional[str] = None,
+    last_name: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    is_superuser: Optional[bool] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """List DefectDojo users with optional filtering and pagination.
+
+    Users represent people who interact with DefectDojo — security
+    engineers, developers, managers, etc.
+
+    Args:
+        username: Optional username filter (exact match).
+        first_name: Optional first name filter (partial match).
+        last_name: Optional last name filter (partial match).
+        is_active: Filter by active status. ``True`` for active users only.
+        is_superuser: Filter by superuser flag.
+        limit: Maximum number of users to return per page (default: 50).
+        offset: Number of records to skip (default: 0).
+
+    Returns:
+        Dictionary with status, data/error, and pagination metadata.
+    """
+    filters: Dict[str, Any] = {"limit": limit, "o": "id"}
+
+    if username:
+        filters["username"] = username
+    if first_name:
+        filters["first_name"] = first_name
+    if last_name:
+        filters["last_name"] = last_name
+    if is_active is not None:
+        filters["is_active"] = is_active
+    if is_superuser is not None:
+        filters["is_superuser"] = is_superuser
+    if offset:
+        filters["offset"] = offset
+
+    client = get_client()
+    result = await client.get_users(filters)
+
+    if "error" in result:
+        return {
+            "status": "error",
+            "error": result["error"],
+            "details": result.get("details", ""),
+        }
+
+    applied = {k: v for k, v in filters.items() if k not in ("limit", "offset", "o")}
+    response: Dict[str, Any] = {"status": "success", "data": result}
+    if applied:
+        response["applied_filters"] = applied
+    return response
+
+
+async def get_user(user_id: int) -> Dict[str, Any]:
+    """Get a specific user by their ID.
+
+    Returns the full user profile including username, email, first/last
+    name, active status, and superuser flag.
+
+    Args:
+        user_id: The unique identifier of the user.
+
+    Returns:
+        Dictionary with status and user data or error.
+    """
+    client = get_client()
+    result = await client.get_user(user_id)
+
+    if "error" in result:
+        return {
+            "status": "error",
+            "error": result["error"],
+            "details": result.get("details", ""),
+        }
+
+    return {"status": "success", "data": result}
+
+
+async def list_dojo_groups(
+    name: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """List DefectDojo groups with optional filtering and pagination.
+
+    Groups are used for role-based access control (RBAC). They
+    organize users into teams with shared permissions on products.
+
+    Args:
+        name: Optional group name filter (partial match).
+        limit: Maximum number of groups to return per page (default: 50).
+        offset: Number of records to skip (default: 0).
+
+    Returns:
+        Dictionary with status, data/error, and pagination metadata.
+    """
+    filters: Dict[str, Any] = {"limit": limit, "o": "id"}
+
+    if name:
+        filters["name"] = name
+    if offset:
+        filters["offset"] = offset
+
+    client = get_client()
+    result = await client.get_dojo_groups(filters)
+
+    if "error" in result:
+        return {
+            "status": "error",
+            "error": result["error"],
+            "details": result.get("details", ""),
+        }
+
+    applied = {k: v for k, v in filters.items() if k not in ("limit", "offset", "o")}
+    response: Dict[str, Any] = {"status": "success", "data": result}
+    if applied:
+        response["applied_filters"] = applied
+    return response
+
+
+async def list_dojo_group_members(
+    group_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """List members of DefectDojo groups with optional filtering.
+
+    Returns group membership records linking users to groups with
+    their assigned roles.
+
+    Args:
+        group_id: Optional group ID to filter members by.
+        user_id: Optional user ID to find their group memberships.
+        limit: Maximum number of records to return per page (default: 50).
+        offset: Number of records to skip (default: 0).
+
+    Returns:
+        Dictionary with status, data/error, and pagination metadata.
+    """
+    filters: Dict[str, Any] = {"limit": limit, "o": "id"}
+
+    if group_id is not None:
+        filters["group"] = group_id
+    if user_id is not None:
+        filters["user"] = user_id
+    if offset:
+        filters["offset"] = offset
+
+    client = get_client()
+    result = await client.get_dojo_group_members(filters)
+
+    if "error" in result:
+        return {
+            "status": "error",
+            "error": result["error"],
+            "details": result.get("details", ""),
+        }
+
+    applied = {k: v for k, v in filters.items() if k not in ("limit", "offset", "o")}
+    response: Dict[str, Any] = {"status": "success", "data": result}
+    if applied:
+        response["applied_filters"] = applied
+    return response
+
+
+# --- Registration Function ---
+
+
+def register_tools(mcp):
+    """Register user-related tools with the MCP server instance."""
+    mcp.tool(
+        name="list_users",
+        description="List DefectDojo users with optional filtering by username, name, and active status",
+    )(list_users)
+    mcp.tool(
+        name="get_user",
+        description="Get a specific DefectDojo user by their ID",
+    )(get_user)
+    mcp.tool(
+        name="list_dojo_groups",
+        description="List DefectDojo groups (teams) with optional name filtering",
+    )(list_dojo_groups)
+    mcp.tool(
+        name="list_dojo_group_members",
+        description="List members of DefectDojo groups with optional group/user filtering",
+    )(list_dojo_group_members)

--- a/tests/test_users_tools.py
+++ b/tests/test_users_tools.py
@@ -1,0 +1,313 @@
+"""Tests for user and group tools: list_users, get_user, list_dojo_groups, list_dojo_group_members."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from defectdojo.users_tools import (
+    get_user,
+    list_dojo_group_members,
+    list_dojo_groups,
+    list_users,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+USER_RESPONSE: Dict[str, Any] = {
+    "id": 1,
+    "username": "admin",
+    "first_name": "Admin",
+    "last_name": "User",
+    "email": "admin@example.com",
+    "is_active": True,
+    "is_superuser": True,
+}
+
+USERS_LIST_RESPONSE: Dict[str, Any] = {
+    "count": 3,
+    "next": None,
+    "previous": None,
+    "results": [
+        {"id": 1, "username": "admin", "is_active": True},
+        {"id": 2, "username": "analyst", "is_active": True},
+        {"id": 3, "username": "viewer", "is_active": False},
+    ],
+}
+
+GROUP_RESPONSE: Dict[str, Any] = {
+    "count": 2,
+    "next": None,
+    "previous": None,
+    "results": [
+        {"id": 1, "name": "AppSec Team"},
+        {"id": 2, "name": "DevOps"},
+    ],
+}
+
+GROUP_MEMBERS_RESPONSE: Dict[str, Any] = {
+    "count": 2,
+    "next": None,
+    "previous": None,
+    "results": [
+        {"id": 10, "group": 1, "user": 1, "role": 4},
+        {"id": 11, "group": 1, "user": 2, "role": 2},
+    ],
+}
+
+ERROR_RESPONSE: Dict[str, Any] = {
+    "error": "HTTP error: 404",
+    "details": "Not Found",
+}
+
+
+# ---------------------------------------------------------------------------
+# list_users
+# ---------------------------------------------------------------------------
+
+
+class TestListUsers:
+    """Tests for the list_users tool function."""
+
+    @pytest.mark.asyncio
+    async def test_no_filters(self):
+        client = AsyncMock()
+        client.get_users.return_value = USERS_LIST_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_users()
+
+        assert result["status"] == "success"
+        assert result["data"]["count"] == 3
+        assert len(result["data"]["results"]) == 3
+        assert "applied_filters" not in result
+
+    @pytest.mark.asyncio
+    async def test_username_filter(self):
+        filtered = {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [{"id": 1, "username": "admin", "is_active": True}],
+        }
+        client = AsyncMock()
+        client.get_users.return_value = filtered
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_users(username="admin")
+
+        assert result["status"] == "success"
+        assert result["applied_filters"] == {"username": "admin"}
+
+    @pytest.mark.asyncio
+    async def test_is_active_filter(self):
+        client = AsyncMock()
+        client.get_users.return_value = USERS_LIST_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_users(is_active=True)
+
+        assert result["status"] == "success"
+        assert result["applied_filters"]["is_active"] is True
+        call_args = client.get_users.call_args[0][0]
+        assert call_args["is_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_combined_filters(self):
+        client = AsyncMock()
+        client.get_users.return_value = USERS_LIST_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_users(first_name="Admin", is_active=True, is_superuser=True)
+
+        assert result["status"] == "success"
+        applied = result["applied_filters"]
+        assert applied["first_name"] == "Admin"
+        assert applied["is_active"] is True
+        assert applied["is_superuser"] is True
+
+    @pytest.mark.asyncio
+    async def test_pagination(self):
+        client = AsyncMock()
+        client.get_users.return_value = USERS_LIST_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_users(limit=10, offset=20)
+
+        assert result["status"] == "success"
+        call_args = client.get_users.call_args[0][0]
+        assert call_args["limit"] == 10
+        assert call_args["offset"] == 20
+
+    @pytest.mark.asyncio
+    async def test_api_error(self):
+        client = AsyncMock()
+        client.get_users.return_value = ERROR_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_users()
+
+        assert result["status"] == "error"
+        assert "404" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_user
+# ---------------------------------------------------------------------------
+
+
+class TestGetUser:
+    """Tests for the get_user tool function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        client = AsyncMock()
+        client.get_user.return_value = USER_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await get_user(user_id=1)
+
+        assert result["status"] == "success"
+        assert result["data"]["username"] == "admin"
+        assert result["data"]["is_superuser"] is True
+        client.get_user.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_not_found(self):
+        client = AsyncMock()
+        client.get_user.return_value = ERROR_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await get_user(user_id=999999)
+
+        assert result["status"] == "error"
+        assert "404" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# list_dojo_groups
+# ---------------------------------------------------------------------------
+
+
+class TestListDojoGroups:
+    """Tests for the list_dojo_groups tool function."""
+
+    @pytest.mark.asyncio
+    async def test_no_filters(self):
+        client = AsyncMock()
+        client.get_dojo_groups.return_value = GROUP_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_groups()
+
+        assert result["status"] == "success"
+        assert result["data"]["count"] == 2
+        assert len(result["data"]["results"]) == 2
+        assert "applied_filters" not in result
+
+    @pytest.mark.asyncio
+    async def test_name_filter(self):
+        filtered = {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [{"id": 1, "name": "AppSec Team"}],
+        }
+        client = AsyncMock()
+        client.get_dojo_groups.return_value = filtered
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_groups(name="AppSec")
+
+        assert result["status"] == "success"
+        assert result["applied_filters"] == {"name": "AppSec"}
+
+    @pytest.mark.asyncio
+    async def test_pagination(self):
+        client = AsyncMock()
+        client.get_dojo_groups.return_value = GROUP_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_groups(limit=5, offset=10)
+
+        assert result["status"] == "success"
+        call_args = client.get_dojo_groups.call_args[0][0]
+        assert call_args["limit"] == 5
+        assert call_args["offset"] == 10
+
+    @pytest.mark.asyncio
+    async def test_api_error(self):
+        client = AsyncMock()
+        client.get_dojo_groups.return_value = ERROR_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_groups()
+
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# list_dojo_group_members
+# ---------------------------------------------------------------------------
+
+
+class TestListDojoGroupMembers:
+    """Tests for the list_dojo_group_members tool function."""
+
+    @pytest.mark.asyncio
+    async def test_no_filters(self):
+        client = AsyncMock()
+        client.get_dojo_group_members.return_value = GROUP_MEMBERS_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_group_members()
+
+        assert result["status"] == "success"
+        assert result["data"]["count"] == 2
+        assert "applied_filters" not in result
+
+    @pytest.mark.asyncio
+    async def test_group_filter(self):
+        client = AsyncMock()
+        client.get_dojo_group_members.return_value = GROUP_MEMBERS_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_group_members(group_id=1)
+
+        assert result["status"] == "success"
+        assert result["applied_filters"]["group"] == 1
+        call_args = client.get_dojo_group_members.call_args[0][0]
+        assert call_args["group"] == 1
+
+    @pytest.mark.asyncio
+    async def test_user_filter(self):
+        client = AsyncMock()
+        client.get_dojo_group_members.return_value = GROUP_MEMBERS_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_group_members(user_id=2)
+
+        assert result["status"] == "success"
+        assert result["applied_filters"]["user"] == 2
+
+    @pytest.mark.asyncio
+    async def test_combined_filters(self):
+        client = AsyncMock()
+        client.get_dojo_group_members.return_value = GROUP_MEMBERS_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_group_members(group_id=1, user_id=2)
+
+        assert result["status"] == "success"
+        applied = result["applied_filters"]
+        assert applied["group"] == 1
+        assert applied["user"] == 2
+
+    @pytest.mark.asyncio
+    async def test_pagination(self):
+        client = AsyncMock()
+        client.get_dojo_group_members.return_value = GROUP_MEMBERS_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_group_members(limit=10, offset=5)
+
+        assert result["status"] == "success"
+        call_args = client.get_dojo_group_members.call_args[0][0]
+        assert call_args["limit"] == 10
+        assert call_args["offset"] == 5
+
+    @pytest.mark.asyncio
+    async def test_api_error(self):
+        client = AsyncMock()
+        client.get_dojo_group_members.return_value = ERROR_RESPONSE
+        with patch("defectdojo.users_tools.get_client", return_value=client):
+            result = await list_dojo_group_members()
+
+        assert result["status"] == "error"


### PR DESCRIPTION
## Summary

Closes #8

Add 4 new MCP tools for user and group management in DefectDojo. This enables identity-aware security operations — resolving user IDs, understanding ownership, and auditing group access.

## New Tools

| Tool | Purpose | API Endpoint |
| --- | --- | --- |
| `list_users` | List users with filtering by username, name, active status, superuser flag | `GET /api/v2/users/` |
| `get_user` | Get a specific user by ID with full profile | `GET /api/v2/users/{id}/` |
| `list_dojo_groups` | List DefectDojo groups (teams) with optional name filter | `GET /api/v2/dojo_groups/` |
| `list_dojo_group_members` | List group membership records with group/user filtering | `GET /api/v2/dojo_group_members/` |

## Changes

### `client.py`
- Added 4 new API methods: `get_users`, `get_user`, `get_dojo_groups`, `get_dojo_group_members`

### `users_tools.py` (new file)
- `list_users(username, first_name, last_name, is_active, is_superuser, limit, offset)`
- `get_user(user_id)`
- `list_dojo_groups(name, limit, offset)`
- `list_dojo_group_members(group_id, user_id, limit, offset)`
- Registration function for all 4 tools

### `tools.py` + `__init__.py`
- Imported and registered all new tools from `users_tools` module

### `test_users_tools.py` (new file)
- 18 unit tests covering all 4 new tools (success, filtering, pagination, error cases)

### `README.md`
- Updated features list with Users & Groups section
- Added tool descriptions to Available Tools
- Added usage examples for all 4 new tools

## Testing

```
98 passed in 1.57s (was 80 before this PR)
```

All existing tests pass. 18 new tests added covering:
- No-filter listing (all users, all groups, all members)
- Individual filters (username, is_active, is_superuser, group name, group_id, user_id)
- Combined filter scenarios
- Pagination (limit + offset)
- API error handling (404, network errors)
- get_user success and not-found cases