### PR TITLE
issue-10: Fix sorting for list_engagements and list_tests tools

### DIFF
--- a/src/defectdojo/engagements_tools.py
+++ b/src/defectdojo/engagements_tools.py
@@ -19,7 +19,7 @@ async def list_engagements(product_id: Optional[int] = None,
     Returns:
         Dictionary with status, data/error, and pagination metadata
     """
-    filters = {"limit": limit}
+    filters = {"limit": limit, "o": "-updated"}
     if product_id:
         filters["product"] = product_id
     if status:

--- a/src/defectdojo/tests_tools.py
+++ b/src/defectdojo/tests_tools.py
@@ -26,7 +26,7 @@ async def list_tests(
     Returns:
         Dictionary with status, data/error, and pagination metadata.
     """
-    filters: Dict[str, Any] = {"limit": limit, "o": "-id"}
+    filters: Dict[str, Any] = {"limit": limit}
 
     if engagement_id is not None:
         filters["engagement"] = engagement_id


### PR DESCRIPTION
## Summary

Fix sorting issues in `list_engagements` and `list_tests` tools.

Closes #10

## Changes

### `list_tests` — remove invalid ordering parameter
- Removed `"o": "-id"` from default filters — this value is not accepted by the DefectDojo tests API and caused HTTP 400 on every call.

### `list_engagements` — add descending sort by updated date
- Added `"o": "-updated"` so the most recently updated engagements are returned first.
- Enables a common use case: getting the last scan date for a product via `list_engagements(product_id=X, limit=1)`.

## Testing

- Manual testing against live DefectDojo instance confirmed both tools now return valid results.